### PR TITLE
Cache dependencies when testing

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,6 +22,18 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
+    # Taken from GitHub actions documentation, with minor modifications
+    - name: Cache node modules
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-node-modules-v1
+      with:
+        path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+        key: build-${{ env.cache-name }}-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          build-${{ env.cache-name }}-
+          build-
+
     # Runs a single command using the runners shell
     - name: Install dependencies
       run: npm install


### PR DESCRIPTION
Caching dependencies speeds up tests, thus saving time waiting and also saving time on Actions.