### PR TITLE
Run npm ci instead of npm install for ci

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,7 +36,7 @@ jobs:
 
     # Runs a single command using the runners shell
     - name: Install dependencies
-      run: npm install
+      run: npm ci
 
     - name: Run tests
       run: npm test


### PR DESCRIPTION
This PR implements this: https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable