### PR TITLE
Add check for type errors as part of CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,45 +10,34 @@ on:
   pull_request:
     branches: [ master ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
-jobs:
-  # This workflow contains a single job called "build"
+    # A workflow run is made up of one or more jobs that can run sequentially or in parallel jobs:
+    # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-16.04
+    # The type of runner that the job will run on runs-on: ubuntu-16.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
+  steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    # Taken from GitHub actions documentation, with minor modifications
     - name: Cache node modules
+      id: npm-cache
       uses: actions/cache@v1
       env:
-        cache-name: cache-node-modules-v1
-      with:
-        path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-        key: build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          build-${{ env.cache-name }}-
-          build-
+        cache-name: build
+        with:
+          path: node_modules
+          key:  ${{ runner.os }}-npm-cache-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-cache-${{ env.cache-name }}-
+            ${{ runner.os }}-npm-cache-
 
-    # Runs a single command using the runners shell
     - name: Install dependencies
-      run: npm ci
+      if: steps.npm-cache.outputs.cache-hit != 'true'
+      run: npm install --no-audit --no-fund
     
     - name: Check type errors
       run: npx tsc --noEmit
 
     - name: Run tests
       run: npm test
-
-    - name: Check for security vulnerabilities
-      run: npm audit --audit-level=moderate
-
-    # Runs a set of commands using the runners shell
-    #- name: Run a multi-line script
-    #  run: |
-    #    echo Add other actions to build,
-    #    echo test, and deploy your project.

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,6 +37,9 @@ jobs:
     # Runs a single command using the runners shell
     - name: Install dependencies
       run: npm ci
+    
+    - name: Check type errors
+      run: npx tsc --noEmit
 
     - name: Run tests
       run: npm test


### PR DESCRIPTION
This PR introduces a step to catch type errors from TypeScript. It does not attempt to build the entire project, solely because we haven't reached that stage yet.