### PR TITLE
Fix race condition in PrivateRoute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3824,6 +3824,12 @@
         "@types/react": "*"
       }
     },
+    "@types/scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
+      "dev": true
+    },
     "@types/serialize-javascript": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@types/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
@@ -13614,9 +13620,9 @@
       }
     },
     "react-hook-form": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-5.6.1.tgz",
-      "integrity": "sha512-pqlAiWyZqngdEVUinxPSmhs9k2L/ETsTf8LU7wfwrE1bXJnslRsb4aKlYiL2z0bgGrCuksN8el5bxFbnR1/qEA=="
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-5.7.2.tgz",
+      "integrity": "sha512-bJvY348vayIvEUmSK7Fvea/NgqbT2racA2IbnJz/aPlQ3GBtaTeDITH6rtCa6y++obZzG6E3Q8VuoXPir7QYUg=="
     },
     "react-is": {
       "version": "16.12.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "jest": {
-    "coverageReporters": ["json", "text"]
+    "coverageReporters": [
+      "json",
+      "text"
+    ]
   },
   "dependencies": {
     "@babel/cli": "^7.10.1",
@@ -86,6 +89,7 @@
     "@types/express": "^4.17.6",
     "@types/http-proxy-middleware": "^0.19.3",
     "@types/morgan": "^1.9.0",
+    "@types/scheduler": "^0.16.1",
     "@types/serialize-javascript": "^1.5.0",
     "core-js": "^3.6.5",
     "eslint": "^6.8.0",
@@ -96,6 +100,7 @@
     "prettier": "^2.0.5",
     "react-test-renderer": "^16.12.0",
     "rimraf": "^3.0.2",
+    "scheduler": "^0.18.0",
     "size-limit": "^4.5.0"
   }
 }

--- a/src/__tests__/App.int.test.tsx
+++ b/src/__tests__/App.int.test.tsx
@@ -113,6 +113,22 @@ describe("Integration test for main app component", () => {
     expect(getByText("404")).toBeInTheDocument();
   });
 
+  it("doesn't hang on private routes", async () => {
+    const history = createMemoryHistory();
+    history.push("/dash/profile");
+    const { queryByRole } = render(<App history={history} />);
+
+    const checkInfo = mockAxios.lastReqGet();
+    await act(async () => {
+      mockAxios.mockResponse(
+        { data: { success: true, data: testUser } },
+        checkInfo
+      );
+    });
+
+    expect(queryByRole("status")).not.toBeInTheDocument();
+  });
+
   it("shouldn't crash if auth check fails", async () => {
     render(<App />);
 

--- a/src/api/__tests__/api.unit.test.ts
+++ b/src/api/__tests__/api.unit.test.ts
@@ -18,6 +18,31 @@ import {
   withStatus,
 } from "../../shared/test-utils";
 
+describe("axiosRequest", () => {
+  it("returns a default error if server returns a string", async () => {
+    const list = listFactory("bingo/");
+    const resp = list();
+    mockAxios.mockResponseFor(
+      {
+        method: "GET",
+        url: "bingo/",
+      },
+      {
+        data: "Error!!!!",
+        status: 500,
+      }
+    );
+    expect(await resp).toEqual(
+      withStatus(500, {
+        success: false,
+        error: {
+          detail: ["REQUEST.DID_NOT_SUCCEED"],
+        },
+      })
+    );
+  });
+});
+
 describe("listFactory", () => {
   afterEach(() => {
     mockAxios.reset();

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -26,6 +26,13 @@ const axiosRequest = async <TResp, TError extends APIError = APIError>(
     validateStatus: () => true,
   };
   return axios({ ...baseConfig, ...config }).then((resp) => {
+    if (typeof resp.data === "string")
+      return {
+        statusCode: resp.status,
+        success: false,
+        error: { detail: ["REQUEST.DID_NOT_SUCCEED"] },
+      };
+
     const success = resp.status >= 200 && resp.status <= 299;
     return {
       statusCode: resp.status,

--- a/src/auth/PrivateRoute.tsx
+++ b/src/auth/PrivateRoute.tsx
@@ -71,7 +71,6 @@ const PrivateRouteWrapper: React.FC<{
         case "error":
           return { ready: false, errors: action.data };
       }
-      return state;
     },
     {
       ready: false,
@@ -93,7 +92,7 @@ const PrivateRouteWrapper: React.FC<{
       } else {
         dispatch({
           type: "error",
-          data: Object.values(resp.error).flat() || ["REQUEST.DID_NOT_SUCCEED"],
+          data: Object.values(resp.error).flat(),
         });
       }
       authCheckCompleted.current = true;

--- a/src/auth/PrivateRoute.tsx
+++ b/src/auth/PrivateRoute.tsx
@@ -96,6 +96,7 @@ const PrivateRouteWrapper: React.FC<{
           data: Object.values(resp.error).flat() || ["REQUEST.DID_NOT_SUCCEED"],
         });
       }
+      authCheckCompleted.current = true;
     });
     authCheckCompleted.current = true;
 

--- a/src/auth/__tests__/PrivateRoute.unit.test.tsx
+++ b/src/auth/__tests__/PrivateRoute.unit.test.tsx
@@ -60,7 +60,7 @@ describe("Unit test for PrivateRoute", () => {
   });
 
   it("shows error page for anonymous users", async () => {
-    const { getByText } = render(
+    const { queryByRole, getByText } = render(
       <Router history={history}>
         <Switch>
           <PrivateRoute path="/private">Secret</PrivateRoute>
@@ -73,11 +73,12 @@ describe("Unit test for PrivateRoute", () => {
       mockAxios.mockResponse({ data: { success: true, data: null } });
     });
 
+    expect(queryByRole("status")).not.toBeInTheDocument();
     expect(getByText("404")).toBeInTheDocument();
   });
 
   it("shows error page when on admin-only routes for logged-in non-admin users", async () => {
-    const { getByText } = render(
+    const { queryByRole, getByText } = render(
       <Router history={history}>
         <Switch>
           <PrivateRoute admin path="/private">
@@ -92,11 +93,12 @@ describe("Unit test for PrivateRoute", () => {
       mockAxios.mockResponse({ data: { success: true, data: testUser } });
     });
 
+    expect(queryByRole("status")).not.toBeInTheDocument();
     expect(getByText("404")).toBeInTheDocument();
   });
 
   it("displays content for logged-in users", async () => {
-    const { getByText } = render(
+    const { queryByRole, getByText } = render(
       <Router history={history}>
         <Switch>
           <PrivateRoute path="/private">Secret</PrivateRoute>
@@ -109,11 +111,12 @@ describe("Unit test for PrivateRoute", () => {
       mockAxios.mockResponse({ data: { success: true, data: testUser } });
     });
 
+    expect(queryByRole("status")).not.toBeInTheDocument();
     expect(getByText("Secret")).toBeInTheDocument();
   });
 
   it("displays admin content for admins", async () => {
-    const { getByText } = render(
+    const { queryByRole, getByText } = render(
       <Router history={history}>
         <Switch>
           <PrivateRoute admin path="/private">
@@ -128,13 +131,14 @@ describe("Unit test for PrivateRoute", () => {
       mockAxios.mockResponse({ data: { success: true, data: testAdmin } });
     });
 
+    expect(queryByRole("status")).not.toBeInTheDocument();
     expect(getByText("Secret")).toBeInTheDocument();
   });
 
   it("shows error page when admin has been downgraded to user", async () => {
     window.__SSR_DIRECTIVES__ = { USER: testAdmin };
 
-    const { getByText } = render(
+    const { queryByRole, getByText } = render(
       <Router history={history}>
         <ForceCheck history={history} />
         <Link to="/admin">Go to admin</Link>
@@ -156,13 +160,14 @@ describe("Unit test for PrivateRoute", () => {
       mockAxios.mockResponse({ data: { success: true, data: testUser } });
     });
 
+    expect(queryByRole("status")).not.toBeInTheDocument();
     expect(getByText("404")).toBeInTheDocument();
   });
 
   it("shows error page when user has been logged out elsewhere", async () => {
     window.__SSR_DIRECTIVES__ = { USER: testUser };
 
-    const { getByText } = render(
+    const { queryByRole, getByText } = render(
       <Router history={history}>
         <ForceCheck history={history} />
         <Link to="/admin">Go to admin</Link>
@@ -182,11 +187,12 @@ describe("Unit test for PrivateRoute", () => {
       mockAxios.mockResponse({ data: { success: true, data: null } });
     });
 
+    expect(queryByRole("status")).not.toBeInTheDocument();
     expect(getByText("404")).toBeInTheDocument();
   });
 
   it("shows errors when auth check fails", async () => {
-    const { getByText } = render(
+    const { queryByRole, getByText } = render(
       <Router history={history}>
         <Switch>
           <PrivateRoute path="/private">Secret</PrivateRoute>
@@ -201,6 +207,7 @@ describe("Unit test for PrivateRoute", () => {
       });
     });
 
+    expect(queryByRole("status")).not.toBeInTheDocument();
     expect(getByText(ERRORS.__TESTING)).toBeInTheDocument();
   });
 });

--- a/src/auth/__tests__/PrivateRoute.unit.test.tsx
+++ b/src/auth/__tests__/PrivateRoute.unit.test.tsx
@@ -59,6 +59,42 @@ describe("Unit test for PrivateRoute", () => {
     expect(mockAxios.get).toHaveBeenLastCalledWith("/api/me/");
   });
 
+  it("renders with render prop if given", async () => {
+    const { queryByRole, getByText } = render(
+      <Router history={history}>
+        <Switch>
+          <PrivateRoute path="/private" render={() => "Secret"} />
+        </Switch>
+      </Router>,
+      { wrapper: AuthProvider }
+    );
+
+    await act(async () => {
+      mockAxios.mockResponse({ data: { success: true, data: testUser } });
+    });
+
+    expect(queryByRole("status")).not.toBeInTheDocument();
+    expect(getByText("Secret")).toBeInTheDocument();
+  });
+
+  it("renders with component prop if given", async () => {
+    const { queryByRole, getByText } = render(
+      <Router history={history}>
+        <Switch>
+          <PrivateRoute path="/private" component={() => <>Secret</>} />
+        </Switch>
+      </Router>,
+      { wrapper: AuthProvider }
+    );
+
+    await act(async () => {
+      mockAxios.mockResponse({ data: { success: true, data: testUser } });
+    });
+
+    expect(queryByRole("status")).not.toBeInTheDocument();
+    expect(getByText("Secret")).toBeInTheDocument();
+  });
+
   it("shows error page for anonymous users", async () => {
     const { queryByRole, getByText } = render(
       <Router history={history}>
@@ -133,6 +169,27 @@ describe("Unit test for PrivateRoute", () => {
 
     expect(queryByRole("status")).not.toBeInTheDocument();
     expect(getByText("Secret")).toBeInTheDocument();
+  });
+
+  it("doesn't render content if NO_PRELOAD_ROUTE directive is given", async () => {
+    window.__SSR_DIRECTIVES__ = { NO_PRELOAD_ROUTE: 1 };
+    const { queryByRole, queryByText } = render(
+      <Router history={history}>
+        <Switch>
+          <PrivateRoute path="/private">Secret</PrivateRoute>
+        </Switch>
+      </Router>,
+      { wrapper: AuthProvider }
+    );
+
+    expect(queryByText("Secret")).not.toBeInTheDocument();
+
+    await act(async () => {
+      mockAxios.mockResponse({ data: { success: true, data: null } });
+    });
+
+    expect(queryByRole("status")).not.toBeInTheDocument();
+    expect(queryByText("Secret")).not.toBeInTheDocument();
   });
 
   it("shows error page when admin has been downgraded to user", async () => {


### PR DESCRIPTION
Fixes #64.

Also introduces a small improvement in how api handles uncontained server errors (which would be delivered in HTML) that I discovered in testing.