### PR TITLE
Update react-bootstrap to 1.3.0 and typescript to 3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17408,9 +17408,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
     },
     "uncontrollable": {
       "version": "7.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17408,9 +17408,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
     },
     "uncontrollable": {
       "version": "7.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4021,9 +4021,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-NMrDy6EWh9TPdSRiHmHH2ye1v5U0gBD7pRYwSwJvomx7Bm4GG04vu63dYiVzebLOx2obPpJugew06xVP0Nk7hA=="
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
+      "integrity": "sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg=="
     },
     "@restart/context": {
       "version": "2.1.4",
@@ -4626,6 +4626,11 @@
         "@types/node": "*"
       }
     },
+    "@types/classnames": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.10.tgz",
+      "integrity": "sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ=="
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -4716,6 +4721,11 @@
         "@types/http-proxy": "*",
         "@types/node": "*"
       }
+    },
+    "@types/invariant": {
+      "version": "2.2.34",
+      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.34.tgz",
+      "integrity": "sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg=="
     },
     "@types/is-hotkey": {
       "version": "0.1.1",
@@ -4897,6 +4907,14 @@
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.2.tgz",
       "integrity": "sha512-4eJr1JFLIAlWhzDkBCkhrOIWOvOxcCAfQh+jiKg7l/nNZcCIL2MHl2dZhogIFKyHzedVWHaVP1Yydq/Ruu4agw==",
       "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
+      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
       "requires": {
         "@types/react": "*"
       }
@@ -7891,26 +7909,31 @@
       }
     },
     "dom-helpers": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.4.tgz",
-      "integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
       "requires": {
         "@babel/runtime": "^7.8.7",
-        "csstype": "^2.6.7"
+        "csstype": "^3.0.2"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.9.6",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
-          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
+        "csstype": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+        },
         "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
       }
     },
@@ -14427,33 +14450,43 @@
       }
     },
     "react-bootstrap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.0.1.tgz",
-      "integrity": "sha512-xMHwsvDN7sIv26P9wWiosWjITZije2dRCjEJHVfV2KFoSJY+8uv2zttEw0XMB7xviQcW3zuIGLJXuj8vf6lYEg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.3.0.tgz",
+      "integrity": "sha512-GYj0c6FO9mx7DaO8Xyz2zs0IcQ6CGCtM3O6/feIoCaG4N8B0+l4eqL7stlMcLpqO4d8NG2PoMO/AbUOD+MO7mg==",
       "requires": {
         "@babel/runtime": "^7.4.2",
         "@restart/context": "^2.1.4",
         "@restart/hooks": "^0.3.21",
-        "@types/react": "^16.9.23",
+        "@types/classnames": "^2.2.10",
+        "@types/invariant": "^2.2.33",
+        "@types/prop-types": "^15.7.3",
+        "@types/react": "^16.9.35",
+        "@types/react-transition-group": "^4.4.0",
+        "@types/warning": "^3.0.0",
         "classnames": "^2.2.6",
         "dom-helpers": "^5.1.2",
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2",
         "prop-types-extra": "^1.1.0",
-        "react-overlays": "^3.1.2",
-        "react-transition-group": "^4.0.0",
+        "react-overlays": "^4.1.0",
+        "react-transition-group": "^4.4.1",
         "uncontrollable": "^7.0.0",
         "warning": "^4.0.3"
       },
       "dependencies": {
         "@types/react": {
-          "version": "16.9.35",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.35.tgz",
-          "integrity": "sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==",
+          "version": "16.9.49",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
+          "integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
           "requires": {
             "@types/prop-types": "*",
-            "csstype": "^2.2.0"
+            "csstype": "^3.0.2"
           }
+        },
+        "csstype": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
         }
       }
     },
@@ -14671,9 +14704,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-overlays": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-3.2.0.tgz",
-      "integrity": "sha512-YTgCmw6l4uBOYylSnc3V8WLX+A0EoGnzDrqkYz0K7MUKbMBZFpaxLXH4EF9eZbspd+syZHQ5XAABI7n/zak1EA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-4.1.0.tgz",
+      "integrity": "sha512-vdRpnKe0ckWOOD9uWdqykLUPHLPndIiUV7XfEKsi5008xiyHCfL8bxsx4LbMrfnxW1LzRthLyfy50XYRFNQqqw==",
       "requires": {
         "@babel/runtime": "^7.4.5",
         "@popperjs/core": "^2.0.0",
@@ -17375,9 +17408,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw=="
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
     },
     "uncontrollable": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "slate": "^0.58.3",
     "slate-history": "^0.58.4",
     "slate-react": "^0.58.4",
-    "typescript": "3.8.3"
+    "typescript": "~3.9.7"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "slate": "^0.58.3",
     "slate-history": "^0.58.4",
     "slate-react": "^0.58.4",
-    "typescript": "^3.8.3"
+    "typescript": "3.8.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node-sass": "^4.14.1",
     "popper.js": "^1.16.0",
     "react": "^16.12.0",
-    "react-bootstrap": "^1.0.1",
+    "react-bootstrap": "^1.3.0",
     "react-dom": "^16.12.0",
     "react-helmet": "^6.0.0",
     "react-hook-form": "^5.6.1",
@@ -54,7 +54,7 @@
     "slate": "^0.58.3",
     "slate-history": "^0.58.4",
     "slate-react": "^0.58.4",
-    "typescript": "^3.7.5"
+    "typescript": "^3.8.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,10 +24,10 @@ interface AppProps {
   history?: History;
 }
 
-export const appFactory = <T extends any = {}>(
-  Component: React.ComponentType<T>
-): React.FC<T> => {
-  return (props: T) => (
+export const appFactory = <P extends any = {}>(
+  Component: React.ComponentType<P>
+): React.FC<P> => {
+  return (props: React.PropsWithChildren<P>) => (
     <>
       <BaseVisor />
       <SluglineNav />
@@ -40,7 +40,7 @@ export const appFactory = <T extends any = {}>(
   );
 };
 
-const MainApp = () => (
+const MainApp: React.FC = () => (
   <Switch>
     <PrivateRoute path="/dash">
       <Dash />

--- a/src/routes/Public.tsx
+++ b/src/routes/Public.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Home from "../home/Home";
 import Login from "../auth/Login";
 import IssuePage from "../issues/IssuePage";
@@ -42,7 +43,7 @@ export const routes: RouteProps[] = [
   },
 ];
 
-const Public = () => {
+const Public: React.FC = () => {
   return renderRoutes(routes);
 };
 

--- a/src/routes/Public.tsx
+++ b/src/routes/Public.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import type React from "react";
 import Home from "../home/Home";
 import Login from "../auth/Login";
 import IssuePage from "../issues/IssuePage";
 import IssueList from "../issues/IssuesList";
 import Error404 from "../shared/errors/Error404";
 import { renderRoutes } from "../shared/helpers";
-import { RouteProps } from "../shared/types";
+import type { RouteProps } from "../shared/types";
 import api from "../api/api";
 
 export const routes: RouteProps[] = [

--- a/src/shared/form/Field.tsx
+++ b/src/shared/form/Field.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { FormControl, FormControlProps, InputGroup } from "react-bootstrap";
 import { NestDataObject, FieldError, ErrorMessage } from "react-hook-form";
-import { BsPrefixProps, ReplaceProps } from "react-bootstrap/helpers";
 import ERRORS from "../errors";
 
-type FormControlElement = HTMLInputElement &
+export type FormControlElement = HTMLInputElement &
   HTMLSelectElement &
   HTMLTextAreaElement;
 
-interface FieldPropsExtra<T> extends FormControlProps {
+export interface FieldProps<T = any>
+  extends FormControlProps,
+    Omit<React.ComponentPropsWithoutRef<"input">, keyof FormControlProps> {
   name: string;
   errors: NestDataObject<T, FieldError>;
   hideErrorMessage?: boolean;
@@ -17,14 +18,7 @@ interface FieldPropsExtra<T> extends FormControlProps {
   append?: JSX.Element;
 }
 
-// This abomination combines our props with the Form.Control props
-// so we can forward them through
-export type FieldProps<
-  As extends React.ElementType = "input"
-> = FieldPropsExtra<any> &
-  Omit<ReplaceProps<As, BsPrefixProps<As> & FormControlProps>, "ref">;
-
-const Field = React.forwardRef<FormControl & FormControlElement, FieldProps>(
+const Field = React.forwardRef<FormControlElement, FieldProps>(
   (props, forwardedRef) => {
     const {
       name,

--- a/src/shared/form/Field.tsx
+++ b/src/shared/form/Field.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-import { FormControl, FormControlProps, InputGroup } from "react-bootstrap";
-import { NestDataObject, FieldError, ErrorMessage } from "react-hook-form";
+import { FormControl, InputGroup } from "react-bootstrap";
+import type { FormControlProps } from "react-bootstrap";
+import { ErrorMessage } from "react-hook-form";
+import type { NestDataObject, FieldError } from "react-hook-form";
 import ERRORS from "../errors";
 
-export type FormControlElement = HTMLInputElement &
+export type FormControlElementType = HTMLInputElement &
   HTMLSelectElement &
   HTMLTextAreaElement;
 
@@ -18,7 +20,7 @@ export interface FieldProps<T = any>
   append?: JSX.Element;
 }
 
-const Field = React.forwardRef<FormControlElement, FieldProps>(
+const Field = React.forwardRef<FormControlElementType, FieldProps>(
   (props, forwardedRef) => {
     const {
       name,

--- a/src/shared/form/PasswordField.tsx
+++ b/src/shared/form/PasswordField.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
-import Field, { FormControlElement, FieldProps } from "./Field";
+import Field from "./Field";
+import type { FormControlElementType, FieldProps } from "./Field";
 import { Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
-import { FormContextValues } from "react-hook-form";
+import type { FormContextValues } from "react-hook-form";
 
 type PasswordFieldProps<T> = Omit<FieldProps, "errors"> & {
   context: FormContextValues<T>;
@@ -26,7 +27,7 @@ export const validatePassword = {
 };
 
 const PasswordField = React.forwardRef<
-  FormControlElement,
+  FormControlElementType,
   PasswordFieldProps<any>
 >(({ state = useState<boolean>(false), context, ...props }, ref) => {
   const [showPassword, setShowPassword] = state;

--- a/src/shared/form/PasswordField.tsx
+++ b/src/shared/form/PasswordField.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import Field, { FieldProps } from "./Field";
+import Field, { FormControlElement, FieldProps } from "./Field";
 import { Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
@@ -25,40 +25,40 @@ export const validatePassword = {
   },
 };
 
-const PasswordField = React.forwardRef<any, PasswordFieldProps<any>>(
-  ({ state = useState<boolean>(false), context, ...props }, ref) => {
-    const [showPassword, setShowPassword] = state;
-    return (
-      <Field
-        type={showPassword ? "text" : "password"}
-        name="password"
-        append={
-          <Button
-            title={showPassword ? "Mask password" : "Show password"}
-            variant={showPassword ? "outline-primary" : "outline-secondary"}
-            onClick={() => {
-              setShowPassword((show) => !show);
-            }}
-          >
-            {showPassword ? (
-              <FontAwesomeIcon icon={faEyeSlash} />
-            ) : (
-              <FontAwesomeIcon icon={faEye} />
-            )}
-          </Button>
-        }
-        errors={context.errors}
-        ref={
-          ref ||
-          context.register({
-            required: "USER.PASSWORD.NEW_REQUIRED",
-            validate: validatePassword,
-          })
-        }
-        {...props}
-      />
-    );
-  }
-);
+const PasswordField = React.forwardRef<
+  FormControlElement,
+  PasswordFieldProps<any>
+>(({ state = useState<boolean>(false), context, ...props }, ref) => {
+  const [showPassword, setShowPassword] = state;
+  return (
+    <Field
+      type={showPassword ? "text" : "password"}
+      append={
+        <Button
+          title={showPassword ? "Mask password" : "Show password"}
+          variant={showPassword ? "outline-primary" : "outline-secondary"}
+          onClick={() => {
+            setShowPassword((show) => !show);
+          }}
+        >
+          {showPassword ? (
+            <FontAwesomeIcon icon={faEyeSlash} />
+          ) : (
+            <FontAwesomeIcon icon={faEye} />
+          )}
+        </Button>
+      }
+      errors={context.errors}
+      ref={
+        ref ||
+        context.register({
+          required: "USER.PASSWORD.NEW_REQUIRED",
+          validate: validatePassword,
+        })
+      }
+      {...props}
+    />
+  );
+});
 
 export default PasswordField;

--- a/src/shared/form/util.ts
+++ b/src/shared/form/util.ts
@@ -1,5 +1,5 @@
-import { FormContextValues } from "react-hook-form";
-import { APIError } from "../types";
+import type { FormContextValues } from "react-hook-form";
+import type { APIError } from "../types";
 
 export const cleanFormData = <T extends {}>(data: T): Partial<T> => {
   let ret: Partial<T> = {};

--- a/src/shared/form/util.ts
+++ b/src/shared/form/util.ts
@@ -1,10 +1,14 @@
 import { FormContextValues } from "react-hook-form";
 import { APIError } from "../types";
 
-export const cleanFormData = <T>(data: T): Partial<T> => {
-  return Object.fromEntries(
-    Object.entries(data).filter(([key, value]) => value !== "")
-  );
+export const cleanFormData = <T extends {}>(data: T): Partial<T> => {
+  let ret: Partial<T> = {};
+  for (const key in data) {
+    if (data.hasOwnProperty(key) && ((data[key] as unknown) as string) !== "") {
+      ret[key] = data[key];
+    }
+  }
+  return ret;
 };
 
 export const setServerErrors = <T, E extends APIError>(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,9 +1,9 @@
-import {
+import type {
   RouteComponentProps as _RouteComponentProps,
   RouteProps as _RouteProps,
   StaticRouterContext,
 } from "react-router";
-import React from "react";
+import type React from "react";
 
 declare global {
   interface Window {


### PR DESCRIPTION
See title.

This also means we can start using `import type` declarations and top-level await, the former which might also reduce our bundle size slightly.