### PR TITLE
Add list support

### DIFF
--- a/src/editor/EditorControls.tsx
+++ b/src/editor/EditorControls.tsx
@@ -70,6 +70,16 @@ const EditorControls: React.FC = () => {
         title="Code Block"
         blockType={BlockElementType.Code}
       />
+      <ToggleBlockButton
+        icon="list-ul"
+        title="Unordered List"
+        blockType={BlockElementType.UnorderedList}
+      />
+      <ToggleBlockButton
+        icon="list-ol"
+        title="Ordered List"
+        blockType={BlockElementType.OrderedList}
+      />
       <ExtrasDropdown />
     </div>
   );

--- a/src/editor/SluglineEditor.tsx
+++ b/src/editor/SluglineEditor.tsx
@@ -45,6 +45,12 @@ const renderElement = (props: RenderElementProps) => {
           {props.children}
         </pre>
       );
+    case BlockElementType.OrderedList:
+      return <ol>{props.children}</ol>;
+    case BlockElementType.UnorderedList:
+      return <ul>{props.children}</ul>;
+    case BlockElementType.ListItem:
+      return <li>{props.children}</li>;
     default:
       return <p {...props.attributes}>{props.children}</p>;
   }

--- a/src/editor/__tests__/CustomEditor.unit.test.ts
+++ b/src/editor/__tests__/CustomEditor.unit.test.ts
@@ -386,4 +386,46 @@ describe("insertBreakWithReset", () => {
       },
     ]);
   });
+
+  it("deletes a list when removing the only item", () => {
+    const editor = createCustomEditor();
+    editor.children = [
+      {
+        type: BlockElementType.OrderedList,
+        children: [
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    editor.selection = {
+      anchor: {
+        path: [0, 0, 0],
+        offset: 0,
+      },
+      focus: {
+        path: [0, 0, 0],
+        offset: 0,
+      },
+    };
+
+    editor.insertBreak();
+
+    expect(editor.children).toEqual([
+      {
+        type: BlockElementType.Default,
+        children: [
+          {
+            text: "",
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/src/editor/__tests__/CustomEditor.unit.test.ts
+++ b/src/editor/__tests__/CustomEditor.unit.test.ts
@@ -268,4 +268,122 @@ describe("insertBreakWithReset", () => {
       },
     ]);
   });
+
+  it("doesn't reset paragraph type in a list", () => {
+    const editor = createCustomEditor();
+    editor.children = [
+      {
+        type: BlockElementType.OrderedList,
+        children: [
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 1",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    editor.selection = {
+      anchor: {
+        path: [0, 0, 0],
+        offset: 6,
+      },
+      focus: {
+        path: [0, 0, 0],
+        offset: 6,
+      },
+    };
+
+    editor.insertBreak();
+
+    expect(editor.children).toEqual([
+      {
+        type: BlockElementType.OrderedList,
+        children: [
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 1",
+              },
+            ],
+          },
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("exits the list when in an empty list item", () => {
+    const editor = createCustomEditor();
+    editor.children = [
+      {
+        type: BlockElementType.OrderedList,
+        children: [
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 1",
+              },
+            ],
+          },
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    editor.selection = {
+      anchor: {
+        path: [0, 1, 0],
+        offset: 0,
+      },
+      focus: {
+        path: [0, 1, 0],
+        offset: 0,
+      },
+    };
+
+    editor.insertBreak();
+
+    expect(editor.children).toEqual([
+      {
+        type: BlockElementType.OrderedList,
+        children: [
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 1",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: BlockElementType.Default,
+        children: [
+          {
+            text: "",
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/src/editor/__tests__/list.unit.test.ts
+++ b/src/editor/__tests__/list.unit.test.ts
@@ -1,0 +1,363 @@
+import createCustomEditor from "../CustomEditor";
+import { BlockElementType } from "../types";
+import { toggleBlock } from "../helpers";
+
+describe("lists", () => {
+  it("toggles single blocks into single item lists", () => {
+    const editor = createCustomEditor();
+
+    editor.children = [
+      {
+        type: BlockElementType.Default,
+        children: [
+          {
+            text: "item 1",
+          },
+        ],
+      },
+    ];
+    editor.selection = {
+      anchor: {
+        path: [0, 0],
+        offset: 0,
+      },
+      focus: {
+        path: [0, 0],
+        offset: 0,
+      },
+    };
+
+    toggleBlock(editor, BlockElementType.UnorderedList);
+
+    expect(editor.children).toEqual([
+      {
+        type: BlockElementType.UnorderedList,
+        children: [
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 1",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("toggles multiple blocks into multiple item lists", () => {
+    const editor = createCustomEditor();
+
+    editor.children = [
+      {
+        type: BlockElementType.Default,
+        children: [
+          {
+            text: "item 1",
+          },
+        ],
+      },
+      {
+        type: BlockElementType.Code,
+        children: [
+          {
+            text: "item 2",
+          },
+        ],
+      },
+      {
+        type: BlockElementType.Header1,
+        children: [
+          {
+            text: "item 3",
+          },
+        ],
+      },
+    ];
+    editor.selection = {
+      anchor: {
+        path: [0, 0],
+        offset: 0,
+      },
+      focus: {
+        path: [2, 0],
+        offset: 6,
+      },
+    };
+
+    toggleBlock(editor, BlockElementType.UnorderedList);
+
+    expect(editor.children).toEqual([
+      {
+        type: BlockElementType.UnorderedList,
+        children: [
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 1",
+              },
+            ],
+          },
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 2",
+              },
+            ],
+          },
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 3",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("converts between list types", () => {
+    const editor = createCustomEditor();
+
+    editor.children = [
+      {
+        type: BlockElementType.UnorderedList,
+        children: [
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 1",
+              },
+            ],
+          },
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 2",
+              },
+            ],
+          },
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 3",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    editor.selection = {
+      anchor: {
+        path: [0, 0, 0],
+        offset: 0,
+      },
+      focus: {
+        path: [0, 2, 0],
+        offset: 6,
+      },
+    };
+
+    toggleBlock(editor, BlockElementType.OrderedList);
+
+    expect(editor.children).toEqual([
+      {
+        type: BlockElementType.OrderedList,
+        children: [
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 1",
+              },
+            ],
+          },
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 2",
+              },
+            ],
+          },
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 3",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("splits lists when toggling individual items", () => {
+    const editor = createCustomEditor();
+
+    editor.children = [
+      {
+        type: BlockElementType.OrderedList,
+        children: [
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 1",
+              },
+            ],
+          },
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 2",
+              },
+            ],
+          },
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 3",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    editor.selection = {
+      anchor: {
+        path: [0, 1, 0],
+        offset: 0,
+      },
+      focus: {
+        path: [0, 1, 0],
+        offset: 0,
+      },
+    };
+
+    toggleBlock(editor, BlockElementType.Header1);
+
+    expect(editor.children).toEqual([
+      {
+        type: BlockElementType.OrderedList,
+        children: [
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 1",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: BlockElementType.Header1,
+        children: [
+          {
+            text: "item 2",
+          },
+        ],
+      },
+      {
+        type: BlockElementType.OrderedList,
+        children: [
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 3",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("correctly removes entire lists", () => {
+    const editor = createCustomEditor();
+
+    editor.children = [
+      {
+        type: BlockElementType.OrderedList,
+        children: [
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 1",
+              },
+            ],
+          },
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 2",
+              },
+            ],
+          },
+          {
+            type: BlockElementType.ListItem,
+            children: [
+              {
+                text: "item 3",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    editor.selection = {
+      anchor: {
+        path: [0, 0, 0],
+        offset: 0,
+      },
+      focus: {
+        path: [0, 2, 0],
+        offset: 6,
+      },
+    };
+
+    toggleBlock(editor, BlockElementType.Header1);
+
+    expect(editor.children).toEqual([
+      {
+        type: BlockElementType.Header1,
+        children: [
+          {
+            text: "item 1",
+          },
+        ],
+      },
+      {
+        type: BlockElementType.Header1,
+        children: [
+          {
+            text: "item 2",
+          },
+        ],
+      },
+      {
+        type: BlockElementType.Header1,
+        children: [
+          {
+            text: "item 3",
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/editor/helpers.ts
+++ b/src/editor/helpers.ts
@@ -41,6 +41,16 @@ export const isIterableEmpty = (iterable: Iterable<any>) => {
 };
 
 /**
+ * Returns the first item in `iterable`. Returns `undefined` for an empty iterable.
+ * @param iterable The iterable to return the first item of.
+ */
+export const getFirstFromIterable = <T>(iterable: Iterable<T>) => {
+  for (const i of iterable) {
+    return i;
+  }
+};
+
+/**
  * Returns true if the passed Location contains inlines, and false otherwise
  * @param editor The editor to search in.
  * @param at The location to search at. If at is undefined, the current selection

--- a/src/editor/helpers.ts
+++ b/src/editor/helpers.ts
@@ -8,6 +8,7 @@ import {
   InlineVoidElement,
   BlockElementType,
   InlineElementType,
+  ElementType,
 } from "./types";
 import { HistoryEditor } from "slate-history";
 
@@ -157,7 +158,32 @@ export const isBlockActive = (editor: Editor, blockType: BlockElementType) => {
  * @param blockType The type of block to toggle
  */
 export const toggleBlock = (editor: Editor, blockType: BlockElementType) => {
-  if (isBlockActive(editor, blockType)) {
+  const isActive = isBlockActive(editor, blockType);
+
+  // first, unwrap any lists
+  if (isListActive(editor)) {
+    Transforms.unwrapNodes(editor, {
+      split: true,
+      match: (elem) => isListType((elem as SluglineElement).type),
+    });
+    Transforms.setNodes(
+      editor,
+      { type: BlockElementType.Default },
+      {
+        match: (elem) =>
+          (elem as SluglineElement).type === BlockElementType.ListItem,
+      }
+    );
+  }
+
+  // if the requested block is a list and that list is currently not active,
+  // we are toggling a list ON, and we have to do some wrapping
+  if (isListType(blockType) && !isActive) {
+    Transforms.setNodes(editor, { type: BlockElementType.ListItem });
+    Transforms.wrapNodes(editor, { type: blockType, children: [] });
+  }
+  // otherwise, toggle as usual
+  else if (isActive) {
     Transforms.setNodes(
       editor,
       { type: BlockElementType.Default },
@@ -170,6 +196,20 @@ export const toggleBlock = (editor: Editor, blockType: BlockElementType) => {
       { mode: "all", match: (node) => Editor.isBlock(editor, node) }
     );
   }
+};
+
+export const isListActive = (editor: Editor) => {
+  return (
+    isBlockActive(editor, BlockElementType.OrderedList) ||
+    isBlockActive(editor, BlockElementType.UnorderedList)
+  );
+};
+
+export const isListType = (blockType: ElementType) => {
+  return (
+    blockType === BlockElementType.UnorderedList ||
+    blockType === BlockElementType.OrderedList
+  );
 };
 
 const MARK_HOTKEYS: Array<[Mark, string]> = [

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -69,10 +69,6 @@ export interface ListItemElement extends Element {
   type: BlockElementType.ListItem;
 }
 
-export type ListElementType =
-  | BlockElementType.UnorderedList
-  | BlockElementType.UnorderedList;
-
 export type BlockElement =
   | Header1Element
   | Header2Element

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -21,6 +21,9 @@ export enum BlockElementType {
   Header1 = "header-1",
   Header2 = "header-2",
   Code = "code",
+  UnorderedList = "unordered-list",
+  OrderedList = "ordered-list",
+  ListItem = "list-item",
 }
 
 export type ElementType = InlineElementType | BlockElementType;
@@ -54,7 +57,29 @@ export interface CodeElement extends Element {
   type: BlockElementType.Code;
 }
 
-export type BlockElement = Header1Element | Header2Element | CodeElement;
+export interface UnorderedListElement extends Element {
+  type: BlockElementType.UnorderedList;
+}
+
+export interface OrderedListElement extends Element {
+  type: BlockElementType.OrderedList;
+}
+
+export interface ListItemElement extends Element {
+  type: BlockElementType.ListItem;
+}
+
+export type ListElementType =
+  | BlockElementType.UnorderedList
+  | BlockElementType.UnorderedList;
+
+export type BlockElement =
+  | Header1Element
+  | Header2Element
+  | CodeElement
+  | UnorderedListElement
+  | OrderedListElement
+  | ListItemElement;
 
 export type SluglineElement =
   | DefaultElement

--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -13,6 +13,8 @@ import {
   faCaretUp,
   faCaretDown,
   faHeading,
+  faListOl,
+  faListUl,
 } from "@fortawesome/free-solid-svg-icons";
 
 export const initLibrary = () => {
@@ -29,6 +31,8 @@ export const initLibrary = () => {
     faSort,
     faCaretUp,
     faCaretDown,
-    faHeading
+    faHeading,
+    faListOl,
+    faListUl
   );
 };


### PR DESCRIPTION
This PR adds ordered and un-ordered lists, which enables the all-important N things listicle.

Besides the various boilerplate types a new block type needs, it also adds some additional logic to account for the fact that lists require a level of nesting.

![Screen Shot 2020-09-20 at 9 13 17 PM](https://user-images.githubusercontent.com/7670245/93726826-1d100500-fb86-11ea-99e8-bf36490000d0.png)
